### PR TITLE
Various fixes

### DIFF
--- a/pages/make_info_pages.py
+++ b/pages/make_info_pages.py
@@ -57,40 +57,40 @@ n = p.add_wrapped_text(
     "EMFFAX's source code is available at "
     "https://github.com/mscroggs/emffax")
 
-p.add_block(n + 1, """
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xx.......xxx.x..x.xxx.xx.......xx
-xx.xxxxx.x.x.xx...x.xx.x.xxxxx.xx
-xx.x...x.xxxxx..x.xx...x.x...x.xx
-xx.x...x.x...x.x..x..x.x.x...x.xx
-xx.x...x.xx.xxxxx.xxxx.x.x...x.xx
-xx.xxxxx.x..x..xxx..x.xx.xxxxx.xx
-xx.......x.x.x.x.x.x.x.x.......xx
-xxxxxxxxxxx...xx.x.xx..xxxxxxxxxx
-xx.....x....x.xxx....x..x.x.x.xxx
-xxx.x.x.x.xx.x....xx....x...x.xxx
-xx..x..x.xxx.xx...x.x.xxx.x..xxxx
-xxx....xxxxxxx..xx....x.....xx.xx
-xxx.xx.x.xx..x.x..x.xx.....xxxxxx
-xx.x.xxxx.xxxxxxxx.xxx..xxx.xxxxx
-xx.xxxx..x..x..xx.x.x.xxxxx....xx
-xx..xx..xx.xx.xx.x.x...x...xx..xx
-xxx.xx.x......xxx.x.xx.xx.xxxxxxx
-xx.x.xxxx.x..x...x.xx..xx...x..xx
-xx.xx.x..xx.xxx...x.x.xxxxx...xxx
-xx.xx.x.x..xxx..xx.x.......xx..xx
-xx.xx.xx..x..x.x....xx.......xxxx
-xxxxxxxxxx.xxxxxx..xx..xxx.xx.xxx
-xx.......x.x...xxxx.x..x.x.xx.xxx
-xx.xxxxx.xx.x.xx.x.xxx.xxx.x...xx
-xx.x...x.x....xxx....x.....x...xx
-xx.x...x.x.xxx.....xxx..x.xxxxxxx
-xx.x...x.x...xx...x...x...xx..xxx
-xx.xxxxx.x.xxx..xx...x..xxx..x.xx
-xx.......x...x.x....x....x...xxxx
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-""", Color.WHITE)
+p.add_block(n + 3, """
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+xx.......xxx.x..x.xxx.xx.......xx.
+xx.xxxxx.x.x.xx...x.xx.x.xxxxx.xx.
+xx.x...x.xxxxx..x.xx...x.x...x.xx.
+xx.x...x.x...x.x..x..x.x.x...x.xx.
+xx.x...x.xx.xxxxx.xxxx.x.x...x.xx.
+xx.xxxxx.x..x..xxx..x.xx.xxxxx.xx.
+xx.......x.x.x.x.x.x.x.x.......xx.
+xxxxxxxxxxx...xx.x.xx..xxxxxxxxxx.
+xx.....x....x.xxx....x..x.x.x.xxx.
+xxx.x.x.x.xx.x....xx....x...x.xxx.
+xx..x..x.xxx.xx...x.x.xxx.x..xxxx.
+xxx....xxxxxxx..xx....x.....xx.xx.
+xxx.xx.x.xx..x.x..x.xx.....xxxxxx.
+xx.x.xxxx.xxxxxxxx.xxx..xxx.xxxxx.
+xx.xxxx..x..x..xx.x.x.xxxxx....xx.
+xx..xx..xx.xx.xx.x.x...x...xx..xx.
+xxx.xx.x......xxx.x.xx.xx.xxxxxxx.
+xx.x.xxxx.x..x...x.xx..xx...x..xx.
+xx.xx.x..xx.xxx...x.x.xxxxx...xxx.
+xx.xx.x.x..xxx..xx.x.......xx..xx.
+xx.xx.xx..x..x.x....xx.......xxxx.
+xxxxxxxxxx.xxxxxx..xx..xxx.xx.xxx.
+xx.......x.x...xxxx.x..x.x.xx.xxx.
+xx.xxxxx.xx.x.xx.x.xxx.xxx.x...xx.
+xx.x...x.x....xxx....x.....x...xx.
+xx.x...x.x.xxx.....xxx..x.xxxxxxx.
+xx.x...x.x...xx...x...x...xx..xxx.
+xx.xxxxx.x.xxx..xx...x..xxx..x.xx.
+xx.......x...x.x....x....x...xxxx.
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.
+""", Color.WHITE, indent=11)
 
 p.write()

--- a/pages/make_info_pages.py
+++ b/pages/make_info_pages.py
@@ -12,7 +12,7 @@ p.set_line(2, line)
 n = p.add_wrapped_text(
     4,
     "EMFFAX is a text-based information service inspired by "
-    "CEEFAX (see page 115). EMFFAX was created by "
+    "CEEFAX (see page 114). EMFFAX was created by "
     "Matthew Scroggs (@mscroggs).")
 n = p.add_wrapped_text(
     n + 1,

--- a/pages/make_schedule_pages.py
+++ b/pages/make_schedule_pages.py
@@ -1,6 +1,8 @@
 from pyfax import Page, Line, Color
 from pyfax.tools.url_helpers import load_json
 from datetime import datetime
+from unicodedata import normalize
+
 
 data = load_json("https://www.emfcamp.org/api/villages")
 
@@ -31,14 +33,16 @@ for i in range(len(data) // perpage):
         line = Line()
         line.start_fg(Color.DEFAULT)
         v = perpage * i + j
-        line.add_text((data[v]["name"] + " " * 20)[:20])
+        name = normalize("NFKD", data[v]["name"]).encode('ascii', 'ignore').decode('utf8')
+        desc = normalize("NFKD", data[v]["description"]).encode('ascii', 'ignore').decode('utf8')
+        line.add_text((name + " " + "." * 34)[:34])
         line.start_fg(Color.YELLOW)
         line.add_text(f"{page_n}")
-        p.set_line(3 + j, line)
+        p.set_line(4 + j, line)
         sub_p = Page(page_n)
         line = Line()
         line.start_double_size()
-        line.add_text(data[v]["name"])
+        line.add_text(name)
         sub_p.set_line(2, line)
 
         line = Line()
@@ -50,16 +54,16 @@ for i in range(len(data) // perpage):
 
         if data[v]["name"] in workshop_villages:
             n = workshop_villages[data[v]["name"]]
-            workshop_pages.append((n, data[v]["name"], page_n))
+            workshop_pages.append((n, name, page_n))
             line = Line()
             line.start_fg(Color.DEFAULT)
             line.add_text(f"Workshop {n} ")
             line.start_fg(Color.YELLOW)
             line.add_text(f"{500 + 3 * n - 2}")
             sub_p.set_line(5, line)
-            sub_p.add_wrapped_text(7, data[v]["description"])
+            sub_p.add_wrapped_text(7, desc)
         else:
-            sub_p.add_wrapped_text(6, data[v]["description"])
+            sub_p.add_wrapped_text(6, desc)
 
         sub_p.write()
 

--- a/static/vbit.conf
+++ b/static/vbit.conf
@@ -1,2 +1,2 @@
-header_template= EMFFAX    %%a %e %%b %H:%M/%S
+header_template=  EMFFAX %%# %%a %e %%b %H:%M/%S
 status_display=EMFFAX


### PR DESCRIPTION
This fixes a few problems:

 - Adds the rolling page number back to the header and makes it the right length so that the clock will update properly on all decoders.
 - Improves the village pages by stripping unicode characters that would otherwise break rendering, and showing more of the names. Also fixes a problem where the double height title overwrites the first village in the list.
 - Fixes the missing column of pixels on the QR code and centres it nicely on the page.

The whole service is set up to leave all the rightmost column of characters empty, presumably to try to match the empty column on the left (usually reserved for control codes). This is not actually necessary - every real service uses the rightmost column, and pretty much every TV draws teletext shifted a little to the left in order to compensate for the imbalance.

It's quite important that the clock goes all the way on the right, otherwise the hours digits may not update properly on all TVs, and due to the above it now doesn't match the right margin of the page.

On the updated village pages I made the index conform to the width of all other pages rather than making them match the clock, but that's easy to change (just change 34 to 35). However, making everything else use the full width seems to require changes in pyfax.

In fact a lot of these fixes are actually workarounds for things that should probably be done in pyfax (like better unicode handling).